### PR TITLE
Add support for Markdown compatible anchors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dist
 
 .idea/
 gen-crd-api-reference-docs
+vendor

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,17 @@
 module github.com/ViaQ/gen-crd-api-reference-docs
 
-go 1.15
+go 1.18
 
 require (
 	github.com/pkg/errors v0.8.1
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1
-	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	k8s.io/gengo v0.0.0-20201203183100-97869a43a9d9
 	k8s.io/klog v0.2.0
+)
+
+require (
+	github.com/go-logr/logr v0.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	k8s.io/klog/v2 v2.2.0 // indirect
 )


### PR DESCRIPTION
 This PR adds some functions that make it possible to use Markdown friendly anchors. It also updates to using Go 1.18.