### PR TITLE
YAML spec templates and supporting helpers

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,6 +76,38 @@ type apiPackage struct {
 	Constants  []*types.Type
 }
 
+type nodeMember struct {
+	types.Member
+	Path string
+}
+
+type nodeType struct {
+	*types.Type
+	Path string
+}
+
+func nodeParent(t interface{}, p string) nodeType {
+	var aT *types.Type
+	if n, ok := t.(nodeType); ok {
+		aT = n.Type
+		p = p + "." + n.Path
+	}
+	if aT == nil {
+		n, _ := t.(*types.Type)
+		aT = n
+	}
+
+	return nodeType{aT, p}
+}
+
+func node(m types.Member, path string) nodeMember {
+	name := fieldName(m)
+	if path != "" {
+		name = path + "." + name
+	}
+	return nodeMember{m, path}
+}
+
 func (v *apiPackage) identifier() string { return fmt.Sprintf("%s/%s", v.apiGroup, v.apiVersion) }
 
 func init() {
@@ -345,6 +377,36 @@ func isLocalType(t *types.Type, typePkgMap map[*types.Type]*apiPackage) bool {
 	return ok
 }
 
+func comments(s []string, options ...string) string {
+	s = filterCommentTags(s)
+	doc := strings.Join(s, "\n")
+	if contains(options, "oneline") {
+		doc = strings.Join(s, " ")
+	}
+	if contains(options, "summary") {
+		if len(s) > 0 {
+			doc = s[0]
+		}
+	}
+	for _, op := range options {
+		if op == "markdown" {
+			return string(blackfriday.Run([]byte(doc)))
+		}
+		if op == "html" {
+			return nl2br(doc)
+		}
+	}
+	return doc
+}
+func contains(options []string, value string) bool {
+	for _, op := range options {
+		if op == value {
+			return true
+		}
+	}
+	return false
+}
+
 func renderComments(s []string, markdown bool) string {
 	s = filterCommentTags(s)
 	doc := strings.Join(s, "\n")
@@ -486,6 +548,24 @@ func finalUnderlyingTypeOf(t *types.Type) *types.Type {
 	}
 }
 
+func yamlType(t types.Type) string {
+	kind := t.Kind
+	if kind == types.Pointer {
+		kind = tryDereference(&t).Kind
+	}
+	if t.Name.Name == "Time" {
+		return "string"
+	}
+	switch kind {
+	case types.Slice:
+		return "array"
+	case types.Struct,
+		types.Map:
+		return "object"
+	}
+	return t.Name.Name
+}
+
 func typeDisplayName(t *types.Type, c generatorConfig, typePkgMap map[*types.Type]*apiPackage) string {
 	s := typeIdentifier(t)
 
@@ -608,6 +688,19 @@ func isOptionalMember(m types.Member) bool {
 	return ok
 }
 
+func ignoreMember(m types.Member) bool {
+	tags := types.ExtractCommentTags("+", m.CommentLines)
+	_, ok := tags["docgen:ignore"]
+	return ok
+}
+
+func isObjectRoot(m types.Type) bool {
+	tags := types.ExtractCommentTags("+", m.CommentLines)
+	values, ok := tags["kubebuilder:object:root"]
+	root := len(values) == 1 && values[0] == "true"
+	return ok && root
+}
+
 func apiVersionForPackage(pkg *types.Package) (string, string, error) {
 	group := groupName(pkg)
 	version := pkg.Name // assumes basename (i.e. "v1" in "core/v1") is apiVersion
@@ -656,9 +749,13 @@ func render(w io.Writer, pkgs []*apiPackage, config generatorConfig) error {
 		"isExportedType":     isExportedType,
 		"fieldName":          fieldName,
 		"fieldEmbedded":      fieldEmbedded,
+		"yamlType":           yamlType,
 		"typeIdentifier":     func(t *types.Type) string { return typeIdentifier(t) },
 		"typeDisplayName":    func(t *types.Type) string { return typeDisplayName(t, config, typePkgMap) },
 		"visibleTypes":       func(t []*types.Type) []*types.Type { return visibleTypes(t, config) },
+		"comments":           comments,
+		"node":               node,
+		"nodeParent":         nodeParent,
 		"renderComments":     func(s []string) string { return renderComments(s, !config.MarkdownDisabled) },
 		"packageDisplayName": func(p *apiPackage) string { return p.identifier() },
 		"apiGroup":           func(t *types.Type) string { return apiGroupForType(t, typePkgMap) },
@@ -696,6 +793,8 @@ func render(w io.Writer, pkgs []*apiPackage, config generatorConfig) error {
 		"hiddenMember":      func(m types.Member) bool { return hiddenMember(m, config) },
 		"isLocalType":       isLocalType,
 		"isOptionalMember":  isOptionalMember,
+		"ignoreMember":     ignoreMember,
+		"isObjectRoot":     isObjectRoot,
 		"constantsOfType":   func(t *types.Type) []*types.Type { return constantsOfType(t, typePkgMap[t]) },
 	}).ParseGlob(filepath.Join(*flTemplateDir, "*.tpl"))
 	if err != nil {

--- a/template/yaml/markdown/REAME.md
+++ b/template/yaml/markdown/REAME.md
@@ -1,0 +1,6 @@
+# Templates to produce a markdown API Document as YAML spec
+
+These templates are inspired by producing an API that is relevent to end users who are providing spec via a YAML file
+and not progammatically.  The Red Hat OpenShift 
+[AlertManager docs](https://docs.openshift.com/container-platform/4.11/rest_api/monitoring_apis/alertmanager-monitoring-coreos-com-v1.html#spec-affinity-nodeaffinity-preferredduringschedulingignoredduringexecution-preference-matchexpressions-2) 
+were used as reference 

--- a/template/yaml/markdown/members.tpl
+++ b/template/yaml/markdown/members.tpl
@@ -1,0 +1,65 @@
+{{ define "member" }}
+ {{ if not (eq .Type.Kind "Builtin") }}
+
+{{ if not (or (fieldEmbedded .Member) (hiddenMember .Member))}}
+### {{ .Path }}
+#### Description
+{{ (comments .CommentLines) }}
+####  Type
+{{ (yamlType .Type) }}
+
+{{ template "properties" .Type  }}
+
+{{ template "members" (nodeParent .Type .Path) }}
+
+
+
+{{ end }}
+{{ end }}
+{{ end }}
+
+{{ define "members" }}
+{{ $path := .Path }}
+{{ if .Members }}
+
+   {{ range .Members }}
+       {{ if (or (eq .Name "ObjectMeta") (eq (fieldName .) "TypeMeta")) }}
+        {{ else }}
+         {{if (eq (yamlType .Type) "array") }}
+             {{ $path := (printf "%s.%s[]" $path  (fieldName .)) }}
+             ### {{ $path }}
+             {{ template "type"  (nodeParent .Type.Elem $path ) }}
+         {{ else }}
+            {{ $path := (printf "%s.%s" $path  (fieldName .)) }}
+            {{ template "member" (node . $path) }}
+         {{ end }}
+       {{ end }}
+   {{ end }}
+
+{{ else if .Elem }}
+    {{ template "type" (nodeParent .Elem $path) }}
+{{ else }}
+{{end }}
+
+{{end }}
+
+
+{{ define "properties" }}
+{{ if .Members }}
+### Specification
+|Property|Type|Description|
+|---|---|---|
+   {{ range .Members }}
+       {{ if (or (or (eq (fieldName .) "metadata") (eq (fieldName .) "TypeMeta")) (ignoreMember .)) }}
+       {{ else }}
+           {{ if (isOptionalMember .) }}
+           |{{ (fieldName .) }}|{{ (yamlType .Type)}}| {{ (comments .CommentLines "summary")}}|
+           {{ else }}
+           |{{ (fieldName .) }}|{{ (yamlType .Type)}}| (optional) {{ (comments .CommentLines "summary")}}|
+           {{ end }}
+       {{ end }}
+   {{ end }}
+
+
+{{ end }}
+{{ end }}

--- a/template/yaml/markdown/pkg.tpl
+++ b/template/yaml/markdown/pkg.tpl
@@ -1,0 +1,32 @@
+{{ define "packages" }}
+
+{{ range .packages }}
+
+        {{ range (sortedTypes (visibleTypes .Types ))}}
+            {{ if isObjectRoot . }}
+
+            ##  {{ .Name.Name }}
+            ### Description
+            {{ (comments .CommentLines) }}
+            ###  Type
+            {{ (yamlType .) }}
+            ###  Required
+            {{ if .Members }}
+               {{ range .Members }}
+              {{ if (or (or (eq (fieldName .) "metadata") (eq (fieldName .) "TypeMeta")) (ignoreMember .)) }}
+              {{ else }}
+               * {{ (fieldName .) }}
+               {{ end }}
+               {{ end }}
+
+               {{ template "properties" .  }}
+
+               {{ template "members" (nodeParent . "") }}
+            {{ end }}
+
+            {{ end }}
+        {{ end }}
+{{ end }}
+
+{{ end }}
+

--- a/template/yaml/markdown/type.tpl
+++ b/template/yaml/markdown/type.tpl
@@ -1,0 +1,16 @@
+{{ define "type" }}
+
+### Description
+{{ (comments .CommentLines) }}
+###  Type
+{{ (yamlType .Type) }}
+
+{{ if .Members }}
+
+  {{ template "properties" .Type  }}
+  {{ template "members" (nodeParent .Type .Path) }}
+
+{{ end }}
+
+
+{{ end }}


### PR DESCRIPTION
This PR:

* Adds templates inspired by producing an API that is relevent to end users who are providing spec via a YAML file
and not progammatically.  
* Adds helper functions and structs to support the templates
* Inspired by https://docs.openshift.com/container-platform/4.11/rest_api/monitoring_apis/alertmanager-monitoring-coreos-com-v1.html#spec-affinity-nodeaffinity-preferredduringschedulingignoredduringexecution-preference-matchexpressions-2) 

Sample Result: https://github.com/jcantrill/cluster-logging-operator/blob/docgen/docs/operator/api.md

![image](https://user-images.githubusercontent.com/4548408/200935493-9b1745da-52ef-426b-894b-84c6a5ca83d0.png)
