### PR TITLE
Differentiate []Type from []*Type in type display name

### DIFF
--- a/main.go
+++ b/main.go
@@ -616,6 +616,9 @@ func typeDisplayName(t *types.Type, c generatorConfig, typePkgMap map[*types.Typ
 	}
 
 	if t.Kind == types.Slice {
+		if t.Elem.Kind == types.Pointer {
+			s = "*" + s
+		}
 		s = "[]" + s
 	}
 


### PR DESCRIPTION
This PR allows to display types as []*Type when they are indeed a slice of pointer of type, as opposed to []Type