### PR TITLE
replace consecutive blank lines with a single one to preserve adoc fo…

### DIFF
--- a/main.go
+++ b/main.go
@@ -174,7 +174,8 @@ func main() {
 			return "", errors.Wrap(err, "failed to render the result")
 		}
 		// remove trailing whitespace from each html line for markdown renderers
-		s := regexp.MustCompile(`(?m)^[ \t]+`).ReplaceAllString(b.String(), "")
+		s := regexp.MustCompile(`(?m)^(\s+){2,}`).ReplaceAllString(b.String(), "\r\n")
+		//s := regexp.MustCompile(`^(\s*\r\n){2,}`).ReplaceAllString(b.String(), "\r\n")
 		return s, nil
 	}
 


### PR DESCRIPTION
…rmatting

This PR subtly reverts the previous change to remove blank lines.  It replaces consecutive empty lines with a single empty line.  This allows preserving adoc  formatting while minimizing extraneous spaces

cc @aminesnow 